### PR TITLE
fixes #35 - add remember_me in login form

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -27,7 +27,7 @@ security:
 
         # all remaining routes require authentication
         secured_area:
-            pattern: ^/
+            pattern: '^/'
             anonymous: true
             form_login:
                 login_path: 'majoraotastore_admin_user_login'
@@ -38,6 +38,8 @@ security:
                 path: 'majoraotastore_user_logout'
                 target: 'majoraotastore_admin_user_login'
             provider: 'db_user_provider'
+            remember_me:
+                secret: '%secret%'
 
     role_hierarchy:
         ROLE_ADMIN: ['ROLE_USER']

--- a/src/UserBundle/Resources/translations/messages.en.yml
+++ b/src/UserBundle/Resources/translations/messages.en.yml
@@ -11,6 +11,8 @@ user:
                 label: Email :
             password:
                 label: Password :
+            remember_me:
+                label: Keep me logged in
             submit: Login
     logout:
         title: Logout

--- a/src/UserBundle/Resources/translations/messages.fr.yml
+++ b/src/UserBundle/Resources/translations/messages.fr.yml
@@ -11,6 +11,8 @@ user:
                 label: Email :
             password:
                 label: Mot de passe :
+            remember_me:
+                label: Se souvenir de moi
             submit: Se connecter
     logout:
         title: Se déconnecter

--- a/src/UserBundle/Resources/views/Security/login.html.twig
+++ b/src/UserBundle/Resources/views/Security/login.html.twig
@@ -34,6 +34,11 @@
                 <input type="password" id="password" name="_password" class="form-control"/>
             </div>
 
+            <div class="form-group">
+                <label for="remember_me">{{ 'user.login.form.remember_me.label' | trans }}</label>
+                <input type="checkbox" id="remember_me" name="_remember_me" checked="checked" />
+            </div>
+
             <button type="submit" class="btn btn-default">{{ 'user.login.form.submit' | trans }}</button>
         </form>
     </div>


### PR DESCRIPTION
## Why
Because we want to be able to be logged in during a long period => #35 

## How
Add a "remember me" checkbox on the login form.
Users which check this will be kept connected during `1 year` (if they don't erase their cookies in the meantime).

<img width="189" alt="capture d ecran 2017-01-15 a 23 30 16" src="https://cloud.githubusercontent.com/assets/2571084/21966820/40f856e0-db7b-11e6-94dd-3e31766ea8de.png">
