### PR TITLE
refacto slug and label unique constraint

### DIFF
--- a/app/DoctrineMigrations/Version20170626205956.php
+++ b/app/DoctrineMigrations/Version20170626205956.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170626205956 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX label_idx ON majoraotastore_application');
+        $this->addSql('DROP INDEX slug_idx ON majoraotastore_application');
+        $this->addSql('ALTER TABLE majoraotastore_application DROP slug');
+        $this->addSql('CREATE UNIQUE INDEX label_support_idx ON majoraotastore_application (`label`, support)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX label_support_idx ON majoraotastore_application');
+        $this->addSql('ALTER TABLE majoraotastore_application ADD slug VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('CREATE UNIQUE INDEX label_idx ON majoraotastore_application (`label`)');
+        $this->addSql('CREATE UNIQUE INDEX slug_idx ON majoraotastore_application (slug)');
+    }
+}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -78,7 +78,6 @@ stof_doctrine_extensions:
     orm:
         default:
             timestampable: true
-            sluggable: true
 
 
 # JWT rsa configuration

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "hautelook/alice-bundle": "1.3.1",
         "friendsofsymfony/jsrouting-bundle": "^2.0@alpha",
         "willdurand/js-translation-bundle": "^2.6.2",
-        "lexik/jwt-authentication-bundle": "^2.2.0"
+        "lexik/jwt-authentication-bundle": "^2.2.0",
+        "cocur/slugify": "^2.5"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5af0e63c25dced120b7db351e7c0116b",
+    "content-hash": "f98ee0308c7ead4d5c0a7a2a0cdb3ca2",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -49,6 +49,70 @@
                 "transliterator"
             ],
             "time": "2017-04-04T11:38:05+00:00"
+        },
+        {
+            "name": "cocur/slugify",
+            "version": "v2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cocur/slugify.git",
+                "reference": "e8167e9a3236044afebd6e8ab13ebeb3ec9ca145"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cocur/slugify/zipball/e8167e9a3236044afebd6e8ab13ebeb3ec9ca145",
+                "reference": "e8167e9a3236044afebd6e8ab13ebeb3ec9ca145",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "laravel/framework": "~5.1",
+                "latte/latte": "~2.2",
+                "league/container": "^2.2.0",
+                "mikey179/vfsstream": "~1.6",
+                "mockery/mockery": "~0.9",
+                "nette/di": "~2.2",
+                "phpunit/phpunit": "~4.8|~5.2",
+                "pimple/pimple": "~1.1",
+                "plumphp/plum": "~0.1",
+                "silex/silex": "~1.3",
+                "symfony/config": "~2.4|~3.0",
+                "symfony/dependency-injection": "~2.4|~3.0",
+                "symfony/http-kernel": "~2.4|~3.0",
+                "twig/twig": "~1.26|~2.0",
+                "zendframework/zend-modulemanager": "~2.2",
+                "zendframework/zend-servicemanager": "~2.2",
+                "zendframework/zend-view": "~2.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cocur\\Slugify\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ivo Bathke",
+                    "email": "ivo.bathke@gmail.com"
+                },
+                {
+                    "name": "Florian Eckerstorfer",
+                    "email": "florian@eckerstorfer.co",
+                    "homepage": "https://florian.ec"
+                }
+            ],
+            "description": "Converts a string into a slug.",
+            "keywords": [
+                "slug",
+                "slugify"
+            ],
+            "time": "2017-03-23T21:52:55+00:00"
         },
         {
             "name": "composer/ca-bundle",

--- a/src/ApplicationBundle/Controller/Api/BuildController.php
+++ b/src/ApplicationBundle/Controller/Api/BuildController.php
@@ -137,7 +137,7 @@ class BuildController extends ApiController
         $filename = $request->query->get('filename');
 
         if (!$filename) {
-            $filename = $build->getLabel();
+            $filename = $build->getSlug();
         }
 
         $uploadHelper = $this->container->get('appbuild.application.build_upload_helper');

--- a/src/ApplicationBundle/Entity/Application.php
+++ b/src/ApplicationBundle/Entity/Application.php
@@ -2,6 +2,7 @@
 
 namespace Majora\OTAStore\ApplicationBundle\Entity;
 
+use Cocur\Slugify\Slugify;
 use Doctrine\Common\Collections\ArrayCollection;
 use Majora\OTAStore\UserBundle\Entity\User;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
@@ -26,11 +27,6 @@ class Application
      * @var string
      */
     private $label;
-
-    /**
-     * @var string
-     */
-    private $slug;
 
     /**
      * @var string
@@ -112,19 +108,13 @@ class Application
      */
     public function getSlug()
     {
-        return $this->slug;
-    }
-
-    /**
-     * @param string $slug
-     *
-     * @return $this
-     */
-    public function setSlug($slug)
-    {
-        $this->slug = $slug;
-
-        return $this;
+        return (new Slugify())->slugify(
+            sprintf(
+                '%s-%s',
+                $this->getLabel(),
+                $this->getSupport()
+            )
+        );
     }
 
     /**

--- a/src/ApplicationBundle/Entity/Build.php
+++ b/src/ApplicationBundle/Entity/Build.php
@@ -2,6 +2,7 @@
 
 namespace Majora\OTAStore\ApplicationBundle\Entity;
 
+use Cocur\Slugify\Slugify;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
@@ -77,6 +78,17 @@ class Build
         return sprintf('%s [%s]',
             $application->getLabel(),
             $this->getVersion()
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getSlug()
+    {
+        return sprintf('%s-%s',
+            $this->getApplication()->getSlug(),
+            (new Slugify())->slugify($this->getVersion())
         );
     }
 

--- a/src/ApplicationBundle/Resources/config/doctrine/Application.orm.yml
+++ b/src/ApplicationBundle/Resources/config/doctrine/Application.orm.yml
@@ -7,21 +7,13 @@ Majora\OTAStore\ApplicationBundle\Entity\Application:
             type: integer
             generator: { strategy: AUTO }
     uniqueConstraints:
-        label_idx:
-            columns: label
-        slug_idx:
-            columns: slug
+        label_support_idx:
+            columns:
+                - label
+                - support
     fields:
         label:
             type: string
-        slug:
-            type: string
-            gedmo:
-                slug:
-                    separator: -
-                    style: default
-                    fields:
-                        - label
         support:
             type: string
         packageName:

--- a/src/ApplicationBundle/Resources/fixtures/applications.yml
+++ b/src/ApplicationBundle/Resources/fixtures/applications.yml
@@ -1,7 +1,6 @@
 Majora\OTAStore\ApplicationBundle\Entity\Application:
     test_ios:
         support: ios
-        label: Test application iOS
-        slug: test-application-ios
+        label: Test application
         packageName: com.link-value.test
         enabled: true


### PR DESCRIPTION
BC Break:
- Remove "application.slug" persisted field, but keep `$application->getSlug()`
- `$application->getSlug()` now returns `label-support` instead of only `label`

Features: 
- Add `$build->getSlug()`
- Replace unique constraint on `application.label`, by a unique constraint on `application.label AND application.support`