### PR TITLE
fix issue on using PersistentCollection::matching() with a ManyToMany relation

### DIFF
--- a/src/ApplicationBundle/Controller/BaseController.php
+++ b/src/ApplicationBundle/Controller/BaseController.php
@@ -19,6 +19,6 @@ class BaseController extends Controller
             return new ArrayCollection($this->getDoctrine()->getRepository('MajoraOTAStoreApplicationBundle:Application')->findAll());
         }
 
-        return $this->getUser()->getApplications();
+        return new ArrayCollection($this->getUser()->getApplications()->toArray());
     }
 }


### PR DESCRIPTION
## Why
Because https://github.com/doctrine/doctrine2/issues/5644 (it seems that doctrine's `Criteria` class is not very reliable 😞  especially with manyToMany relations)

## How
Use `ArrayCollection::matching()` instead of `PersistentCollection::matching()` (which works fine because it's a simple array wrapper)