### PR TITLE
fix minify mangling on Safari

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -134,7 +134,7 @@ if (isDev) {
   });
 } else {
   config.plugins.push(
-    new MinifyPlugin()
+    new MinifyPlugin({ mangle: false/* <- to fix Safari issue, hope this will be fixed in a newer version than 0.2.0 */ })
   );
 }
 


### PR DESCRIPTION
## Fixes
- Safari couldn't load Javascript files because of https://github.com/babel/minify/issues/681 (so we disable `mangling` during JS minifying)