### PR TITLE
Update eslint version to non-vulnerable

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-preset-env": "1.6.0",
     "copy-webpack-plugin": "4.0.1",
     "css-loader": "0.27.3",
-    "eslint": "3.19.0",
+    "eslint": "4.18.2",
     "eslint-loader": "1.9.0",
     "extract-text-webpack-plugin": "3.0.0",
     "file-loader": "0.10.1",


### PR DESCRIPTION
Security alert has been thrown by Github for a while now.

Updates `eslint` from `3.19.0` to `4.18.2`, since it's the recommended safe version.

Lint tasks works well without warnings after updating.